### PR TITLE
Add error handling to attribute deserialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,11 @@ module.exports = (function() {
 
         if(node && token.attrs) {
             each(token.attrs, function(attrValue, attrName) {
-                node.setAttribute(attrName, attrValue);
+                try {
+                    node.setAttribute(attrName, attrValue);
+                } catch(e) {
+                    console.error('[dom2json] Couldn\'t set attribute "' + attrName + '" to "' + attrValue + '"', e, node);
+                }
             });
         }
 

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ module.exports = (function() {
                 try {
                     node.setAttribute(attrName, attrValue);
                 } catch(e) {
-                    console.error('[dom2json] Couldn\'t set attribute "' + attrName + '" to "' + attrValue + '"', e, node);
+                    console.error('[dom2json] Couldn\'t set attribute "' + attrName + '" to "' + attrValue + '"', e, token, node);
                 }
             });
         }


### PR DESCRIPTION
Browser may differ in what they accept as a valid attribute name,
plus they may accept something added via different method (like
HTML parsing) while they throw error on setAttribute.
